### PR TITLE
Fix broken link to demo

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -99,7 +99,7 @@ Touchpoints focuses on providing easy-to-use PRA-friendly feedback forms. If you
 
 ### How options do I have for sharing a Touchpoint form with customers?
 
-* Share a public Touchpoints URL (see a [Demo example](https://touchpoints-demo.app.cloud.gov/touchpoints/1/submit))
+* Share a public Touchpoints URL (see a [Demo example](https://touchpoints.app.cloud.gov/touchpoints/1/submit))
 * javascript embed:
   * render tab that pops a modal with the Form
   * render the Form inline in a page (coming soon)


### PR DESCRIPTION
I _think_ this is the right link...? The existing link gets a 404:
![image](https://user-images.githubusercontent.com/47762/71212014-47363e80-2265-11ea-8981-3061406068e8.png)
